### PR TITLE
Update streaming api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ npm install
 
 #### Register an application
 
-[Create your application](https://typetalk.in/my/develop/applications/register) for using API.
+[Create your application](https://typetalk.com/my/develop/applications/register) for using API.
 
 Grant Type must be Client Credentials.
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ if (!(client_id && client_secret)) {
 
 function issue_access_token(callback) {
   var options = {
-    url: "https://typetalk.in/oauth2/access_token",
+    url: "https://typetalk.com/oauth2/access_token",
     method: 'POST',
     headers:  {
       'Content-Type': 'application/x-www-form-urlencoded'
@@ -33,7 +33,7 @@ function issue_access_token(callback) {
 }
 
 function connect(access_token) {
-  var ws = new WebSocket("https://typetalk.in/api/v1/streaming", {
+  var ws = new WebSocket("https://typetalk.com/api/v1/streaming", {
     headers: {
       'Authorization': 'Bearer ' + access_token
     }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function issue_access_token(callback) {
 }
 
 function connect(access_token) {
-  var ws = new WebSocket("https://typetalk.com/api/v1/streaming", {
+  var ws = new WebSocket("https://message.typetalk.com/api/v1/streaming", {
     headers: {
       'Authorization': 'Bearer ' + access_token
     }


### PR DESCRIPTION
We are going to change streaming api endpoint domain from `typetalk.com` to `message.typetalk.com`.